### PR TITLE
Add Cloudflare Origin CA certificate management and upload to Dokku

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,13 @@
 output "fqdn" {
   value = cloudflare_dns_record.app_record[var.domains[0]].name
 }
+
+output "origin_certificate_id" {
+  description = "ID of the Cloudflare Origin CA certificate"
+  value       = var.manage_origin_certificate ? cloudflare_origin_ca_certificate.app[0].id : null
+}
+
+output "origin_certificate_expires_on" {
+  description = "Expiry date of the Cloudflare Origin CA certificate"
+  value       = var.manage_origin_certificate ? cloudflare_origin_ca_certificate.app[0].expires_on : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -116,3 +116,15 @@ variable "enable_checks" {
   type = bool
   default = true
 }
+
+variable "manage_origin_certificate" {
+  description = "Whether to create and manage a Cloudflare Origin CA certificate for the application"
+  type        = bool
+  default     = false
+}
+
+variable "origin_certificate_validity_days" {
+  description = "Validity period for the Cloudflare Origin CA certificate in days (7, 30, 90, 365, 730, 1825, 5475)"
+  type        = number
+  default     = 5475
+}

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
 
     cloudflare = {
       source = "cloudflare/cloudflare"
-      version = "5.6.0"
+      version = "~>5"
     }
   }
 }


### PR DESCRIPTION
# Changes
- chore(variables): add flags and validity variable for origin certificate management
- chore(cloudflare): create TLS key, CSR, and Origin CA certificate resources with conditional counting
- chore(cloudflare): configure Cloudflare SSL mode to strict when Origin CA is managed
- chore(main): add null_resource to upload Cloudflare Origin CA certificate and private key to Dokku app via remote-exec
- chore(output): expose origin certificate ID and expiry outputs conditionally
- chore(versions): relax cloudflare provider version constraint to "~>5"