### PR TITLE
Update subdomain handling and remote host config in Terraform outputs.tf

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  # If app subdomain is enabled we create a subdomain for the app as well
-  domains = var.enable_app_subdomain ? concat(["${var.name}.${var.root_domain}"], var.domains) : var.domains
+  # If app subdomain is enabled we create a subdomain as well, otherwise we just pass a list of domains
+  domains = var.manage_subdomain ? concat(["${var.name}.${var.root_domain}"], var.domains) : var.domains
   storage = {
     data = {
       mount_path = var.data_dir

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "null_resource" "set_build_dir" {
   }
   provisioner "remote-exec" {
     connection {
-      host        = var.node_ip_address
+      host        = var.host
       user        = "root"
       private_key = var.ssh_private_key
       timeout     = "2m"
@@ -43,7 +43,7 @@ resource "null_resource" "config_set" {
   for_each = var.environment
   provisioner "remote-exec" {
     connection {
-      host        = var.node_ip_address
+      host        = var.host
       user        = "root"
       private_key = var.ssh_private_key
     }
@@ -68,7 +68,8 @@ resource "null_resource" "dokku_cert" {
 
   provisioner "remote-exec" {
     connection {
-      host        = var.node_ip_address
+      host        = var.host
+      # host        = var.node_ip_address
       user        = "root"
       private_key = var.ssh_private_key
     }

--- a/output.tf
+++ b/output.tf
@@ -1,5 +1,5 @@
 output "fqdn" {
-  value = cloudflare_dns_record.app_record[var.domains[0]].name
+  value = "${var.name}.${var.root_domain}" # likely insufficient for cases with app domain enabled, but it's OK for now.
 }
 
 output "origin_certificate_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,10 +8,10 @@ variable "root_domain" {
   type        = string
 }
 
-variable "enable_app_subdomain" {
+variable "manage_subdomain" {
   description = "Whether to enable a subdomain for the application"
   type        = bool
-  default     = false
+  default     = true
 }
 
 


### PR DESCRIPTION
# Changes
- chore(variables.tf): rename enable_app_subdomain to manage_subdomain and default to true
- chore(locals.tf): update domains local to use manage_subdomain variable for subdomain inclusion
- chore(main.tf): replace var.node_ip_address with var.host for remote-exec connections
- chore(output.tf): change fqdn output to use var.name and var.root_domain concatenation with caution note