### PR TITLE
Add support for Cloudflare Tunnel and enhance Cloudflare integration

### DIFF
--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -2,16 +2,18 @@ resource "cloudflare_dns_record" "app_record" {
   for_each = var.manage_cloudflare ? toset(local.domains) : toset([])
   zone_id  = data.cloudflare_zone.this.zone_id
   comment  = "${each.value} host"
-  content  = var.node_ip_address
-  name     = each.value
-  proxied  = var.dns_record_proxied
 
-  ttl  = var.dns_record_ttl
-  type = "A"
+  # Conditional: CNAME for tunnel, A record for direct IP
+  type     = var.cloudflare_tunnel_enabled ? "CNAME" : "A"
+  content  = var.cloudflare_tunnel_enabled ? "${var.cloudflare_tunnel_id}.cfargotunnel.com" : var.node_ip_address
+
+  name     = each.value
+  proxied  = var.cloudflare_dns_record_proxied
+  ttl      = var.cloudflare_dns_record_ttl
 }
 
 resource "cloudflare_page_rule" "http_to_https" {
-  for_each = var.manage_cloudflare && var.manage_https_redirect ? toset(local.domains) : toset([])
+  for_each = var.manage_cloudflare && var.cloudflare_manage_https_redirect ? toset(local.domains) : toset([])
 
   zone_id  = data.cloudflare_zone.this.zone_id
   target   = "http://${each.value}/*"
@@ -26,7 +28,7 @@ resource "cloudflare_page_rule" "http_to_https" {
 
 
 resource "cloudflare_dns_record" "dns_records" {
-  for_each = var.manage_cloudflare ? { for idx, record in var.dns_records : idx => record } : {}
+  for_each = var.manage_cloudflare ? { for idx, record in var.cloudflare_dns_records : idx => record } : {}
   zone_id  = data.cloudflare_zone.this.zone_id
   comment  = "${var.name} DNS Record"
   content  = each.value.content
@@ -39,14 +41,14 @@ resource "cloudflare_dns_record" "dns_records" {
 
 # Generate private key for Origin CA certificate
 resource "tls_private_key" "origin_ca" {
-  count     = var.manage_cloudflare && var.manage_origin_certificate ? 1 : 0
+  count     = var.manage_cloudflare && var.cloudflare_origin_certificate_enabled ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 2048
 }
 
 # Create certificate signing request
 resource "tls_cert_request" "origin_ca" {
-  count           = var.manage_cloudflare && var.manage_origin_certificate ? 1 : 0
+  count           = var.manage_cloudflare && var.cloudflare_origin_certificate_enabled ? 1 : 0
   private_key_pem = tls_private_key.origin_ca[0].private_key_pem
 
   subject {
@@ -59,16 +61,16 @@ resource "tls_cert_request" "origin_ca" {
 
 # Cloudflare Origin CA Certificate for Dokku app
 resource "cloudflare_origin_ca_certificate" "app" {
-  count              = var.manage_cloudflare && var.manage_origin_certificate ? 1 : 0
+  count              = var.manage_cloudflare && var.cloudflare_origin_certificate_enabled ? 1 : 0
   csr                = tls_cert_request.origin_ca[0].cert_request_pem
   hostnames          = local.domains
   request_type       = "origin-rsa"
-  requested_validity = var.origin_certificate_validity_days
+  requested_validity = var.cloudflare_origin_certificate_validity_days
 }
 
 # Set SSL mode to Full (strict) when using Origin CA certificate
 resource "cloudflare_zone_setting" "ssl_mode" {
-  count      = var.manage_cloudflare && var.manage_origin_certificate ? 1 : 0
+  count      = var.manage_cloudflare && var.cloudflare_origin_certificate_enabled ? 1 : 0
   zone_id    = data.cloudflare_zone.this.zone_id
   setting_id = "ssl"
   value      = "strict"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ resource "dokku_app" "this" {
   }
 
   checks = {
-    status =  var.enable_checks ? "enabled" : "disabled"
+    status = var.health_checks_enabled ? "enabled" : "disabled"
   }
 
   config = merge({ APP_NAME = var.name }, var.environment)
@@ -60,7 +60,7 @@ resource "null_resource" "config_set" {
 
 # Upload Cloudflare Origin CA certificate to Dokku
 resource "null_resource" "dokku_cert" {
-  count = var.manage_origin_certificate ? 1 : 0
+  count = var.cloudflare_origin_certificate_enabled ? 1 : 0
 
   triggers = {
     cert_id = cloudflare_origin_ca_certificate.app[0].id

--- a/output.tf
+++ b/output.tf
@@ -4,10 +4,20 @@ output "fqdn" {
 
 output "origin_certificate_id" {
   description = "ID of the Cloudflare Origin CA certificate"
-  value       = var.manage_origin_certificate ? cloudflare_origin_ca_certificate.app[0].id : null
+  value       = var.cloudflare_origin_certificate_enabled ? cloudflare_origin_ca_certificate.app[0].id : null
 }
 
 output "origin_certificate_expires_on" {
   description = "Expiry date of the Cloudflare Origin CA certificate"
-  value       = var.manage_origin_certificate ? cloudflare_origin_ca_certificate.app[0].expires_on : null
+  value       = var.cloudflare_origin_certificate_enabled ? cloudflare_origin_ca_certificate.app[0].expires_on : null
+}
+
+output "cloudflare_tunnel_cname" {
+  description = "Cloudflare Tunnel CNAME target (if tunnel is enabled)"
+  value       = var.cloudflare_tunnel_enabled ? "${var.cloudflare_tunnel_id}.cfargotunnel.com" : null
+}
+
+output "cloudflare_tunnel_id" {
+  description = "Cloudflare Tunnel ID (if tunnel is enabled)"
+  value       = var.cloudflare_tunnel_enabled ? var.cloudflare_tunnel_id : null
 }

--- a/validations.tf
+++ b/validations.tf
@@ -1,0 +1,13 @@
+locals {
+  # Validation: ensure cloudflare_tunnel_id is set when tunnel is enabled
+  validate_tunnel_config = (
+    var.manage_cloudflare && var.cloudflare_tunnel_enabled && var.cloudflare_tunnel_id == "" ?
+    tobool("ERROR: cloudflare_tunnel_id is required when cloudflare_tunnel_enabled is true") : true
+  )
+
+  # Validation: ensure node_ip_address is set when tunnel is disabled
+  validate_ip_config = (
+    var.manage_cloudflare && !var.cloudflare_tunnel_enabled && var.node_ip_address == "" ?
+    tobool("ERROR: node_ip_address is required when cloudflare_tunnel_enabled is false") : true
+  )
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,7 @@
+# ==============================================================================
+# Application Configuration
+# ==============================================================================
+
 variable "name" {
   description = "Name of the Dokku application to be deployed"
   type        = string
@@ -8,12 +12,27 @@ variable "root_domain" {
   type        = string
 }
 
+variable "domains" {
+  description = "The list of domains for the app."
+  type        = list(string)
+  default     = []
+}
+
 variable "manage_subdomain" {
   description = "Whether to enable a subdomain for the application"
   type        = bool
   default     = true
 }
 
+variable "environment" {
+  description = "Map of environment variables to set for the Dokku application"
+  type        = map(string)
+  default     = {}
+}
+
+# ==============================================================================
+# Dokku Server Configuration
+# ==============================================================================
 
 variable "host" {
   description = "Hostname of the Dokku server for SSH connections"
@@ -31,100 +50,103 @@ variable "container_port" {
   default     = 5000
 }
 
-variable "dns_record_proxied" {
-  description = "Whether the Cloudflare DNS record should be proxied"
-  type        = bool
-  default     = true
-}
-
-variable "dns_record_ttl" {
-  description = "TTL for the Cloudflare DNS record (only applies when dns_record_proxied is false)"
-  type        = number
-  default     = 1 # for proxied records
-}
-
-variable "node_ip_address" {
-  type        = string
-  description = "The IP address of the dokku node for DNS record creation"
-}
-
-variable "environment" {
-  description = "Map of environment variables to set for the Dokku application"
-  type        = map(string)
-  default     = {}
-}
-
-variable "manage_cloudflare" {
-  description = "Whether to manage Cloudflare resources (DNS records and page rules)"
-  type        = bool
-  default     = true
-}
-
-
-variable "manage_https_redirect" {
-  description = "Whether to manage Cloudflare http to https redurect"
-  type        = bool
-  default     = true
-}
-
 variable "data_dir" {
   description = "Storage directory on the host"
   type        = string
   default     = "/data"
 }
 
-variable "extra_storage" {
-  description = "Extra storage mounts"
-  type = map(any)
-  default = {}
-}
-
 variable "docker_options" {
   description = "Additional docker options ( # https://dokku.com/docs/advanced-usage/docker-options/)"
-  type = map(any)
-  default = {}
+  type        = map(any)
+  default     = {}
 }
 
+variable "extra_storage" {
+  description = "Extra storage mounts"
+  type        = map(any)
+  default     = {}
+}
 
-variable "dns_records" {
-  description = "DNS Records for the app"
+variable "health_checks_enabled" {
+  description = "Enable health checks (Defined in app.json)"
+  type        = bool
+  default     = true
+}
+
+variable "node_ip_address" {
+  type        = string
+  description = "The IP address of the dokku node for DNS record creation (required when cloudflare_tunnel_enabled is false)"
+  default     = ""
+}
+
+variable "proxy_enabled" {
+  description = "Enable Dokku proxy for the application"
+  type        = bool
+  default     = true
+}
+
+# ==============================================================================
+# Cloudflare Configuration
+# ==============================================================================
+
+variable "cloudflare_dns_record_proxied" {
+  description = "Whether the Cloudflare DNS record should be proxied"
+  type        = bool
+  default     = true
+}
+
+variable "cloudflare_dns_record_ttl" {
+  description = "TTL for the Cloudflare DNS record (only applies when dns_record_proxied is false)"
+  type        = number
+  default     = 1 # for proxied records
+}
+
+variable "cloudflare_dns_records" {
+  description = "Additional DNS records for the app"
   type = list(object({
-    type = string
-    name = string
-    content = string
+    type     = string
+    name     = string
+    content  = string
     priority = number
-    ttl = number
-    proxied = bool
+    ttl      = number
+    proxied  = bool
   }))
   default = []
 }
 
-
-variable "domains" {
-  description = "The list of domains for the app."
-  type = list(string)
-  default = []
+variable "cloudflare_manage_https_redirect" {
+  description = "Whether to manage Cloudflare http to https redirect"
+  type        = bool
+  default     = true
 }
 
-variable "enable_proxy" {
-  type = bool
-  default = true
-}
-
-variable "enable_checks" {
-  description = "Enable health checks (Defined in app.json)"
-  type = bool
-  default = true
-}
-
-variable "manage_origin_certificate" {
+variable "cloudflare_origin_certificate_enabled" {
   description = "Whether to create and manage a Cloudflare Origin CA certificate for the application"
   type        = bool
   default     = false
 }
 
-variable "origin_certificate_validity_days" {
+variable "cloudflare_origin_certificate_validity_days" {
   description = "Validity period for the Cloudflare Origin CA certificate in days (7, 30, 90, 365, 730, 1825, 5475)"
   type        = number
   default     = 5475
+}
+
+variable "cloudflare_tunnel_enabled" {
+  description = "Whether to use Cloudflare Tunnel for DNS routing (CNAME) instead of direct IP (A record)"
+  type        = bool
+  default     = false
+}
+
+variable "cloudflare_tunnel_id" {
+  description = "Cloudflare Tunnel UUID (required when cloudflare_tunnel_enabled is true)"
+  type        = string
+  default     = ""
+}
+
+variable "manage_cloudflare" {
+  description = "Whether to manage Cloudflare resources (DNS records and page rules)"
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
# Changes
- chore(variables): add cloudflare_tunnel_enabled, cloudflare_tunnel_id, and related Cloudflare variables; reorganize and rename variables for clarity
- feat(validations): add validations to require cloudflare_tunnel_id if tunnel enabled and node_ip_address if disabled
- chore(cloudflare): conditionally create Cloudflare DNS records as CNAME for tunnel or A record for IP; update resource counts and variables for origin certificate and page rule
- docs(readme): add examples for Cloudflare Tunnel mode and update docs to reflect new configuration options and outputs
- refactor(main): rename enable_checks to health_checks_enabled; update conditions for origin certificate resource and null resource
- output: add outputs for cloudflare_tunnel_cname and cloudflare_tunnel_id; update origin certificate outputs to use renamed variables